### PR TITLE
feature: add sorting  to addresses transactions

### DIFF
--- a/src/controllers/wallet-address.controller.ts
+++ b/src/controllers/wallet-address.controller.ts
@@ -1,3 +1,4 @@
+import { AddressEventEntity } from 'entity/address-event.entity';
 import express from 'express';
 
 import accountRankService from '../services/account-rank.service';
@@ -8,7 +9,14 @@ export const walletAddressController = express.Router();
 walletAddressController.get('/:id', async (req, res) => {
   const offset: number = Number(req.query.offset) || 0;
   const limit: number = Number(req.query.limit) || 10;
-
+  const sortDirection = req.query.sortDirection === 'ASC' ? 'ASC' : 'DESC';
+  const sortBy = req.query.sortBy as keyof AddressEventEntity;
+  const sortByFields = ['direction', 'transactionHash', 'amount', 'timestamp'];
+  if (sortBy && !sortByFields.includes(sortBy)) {
+    return res.status(400).json({
+      message: `sortBy can be one of following: ${sortByFields.join(',')}`,
+    });
+  }
   if (typeof limit !== 'number' || limit < 0 || limit > 100) {
     return res.status(400).json({ message: 'limit must be between 0 and 100' });
   }
@@ -23,6 +31,8 @@ walletAddressController.get('/:id', async (req, res) => {
       address,
       limit,
       offset,
+      orderBy: sortBy || 'timestamp',
+      orderDirection: sortDirection,
     });
 
     if (!addressEvents || addressEvents.length === 0) {

--- a/src/entity/address-event.entity.ts
+++ b/src/entity/address-event.entity.ts
@@ -25,6 +25,7 @@ export class AddressEventEntity {
     type: 'float',
     nullable: true,
   })
+  @Index()
   public amount: number;
 
   @Column({

--- a/src/entity/address-event.entity.ts
+++ b/src/entity/address-event.entity.ts
@@ -18,6 +18,7 @@ export class AddressEventEntity {
     type: 'int',
     nullable: false,
   })
+  @Index()
   public timestamp: number;
 
   @Column({

--- a/src/migration/1619524507002-AddressEventAmountIndex.ts
+++ b/src/migration/1619524507002-AddressEventAmountIndex.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddressEventAmountIndex1619524507002
+  implements MigrationInterface {
+  name = 'AddressEventAmountIndex1619524507002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5e9ec1221933d26d97cc5ed94a" ON "AddressEvent" ("timestamp") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f882948852a02bcb50d43abe4d" ON "AddressEvent" ("amount") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_f882948852a02bcb50d43abe4d"`);
+    await queryRunner.query(`DROP INDEX "IDX_5e9ec1221933d26d97cc5ed94a"`);
+  }
+}

--- a/src/services/address-events.service.ts
+++ b/src/services/address-events.service.ts
@@ -61,10 +61,14 @@ class AddressEventsService {
     address,
     limit,
     offset,
+    orderBy,
+    orderDirection,
   }: {
     address: string;
     limit: number;
     offset: number;
+    orderBy: keyof AddressEventEntity;
+    orderDirection: 'DESC' | 'ASC';
   }) {
     return this.getRepository().find({
       where: {
@@ -73,6 +77,9 @@ class AddressEventsService {
       select: ['amount', 'timestamp', 'transactionHash'],
       take: limit,
       skip: offset,
+      order: {
+        [orderBy]: orderDirection,
+      },
     });
   }
   async sumAllEventsAmount(address: string, direction: TransferDirectionEnum) {


### PR DESCRIPTION
- Add possibility to sort addresses transactions by 'direction', 'transactionHash', 'amount' and 'timestamp', 
e.g. `/v1/addresses/PtdbJv9yBiK31MrxXrzdEjLkYZu7jeyfKiq?sortBy=direction&sortDirection=DESC`