### PR TITLE
add missing restart by cron

### DIFF
--- a/pm2.yaml
+++ b/pm2.yaml
@@ -12,6 +12,7 @@ apps:
     name: worker
     instances: 1
     exec_mode: cluster
+    cron_restart: "0 2 * * *"
     env:
       PORT: 3001
       NODE_ENV: production


### PR DESCRIPTION
In the #34, restart script for a worker was missing.
This PR adds it. Sorry for not being careful.